### PR TITLE
Create 就算死也要死的有面子.md

### DIFF
--- a/就算死也要死的有面子.md
+++ b/就算死也要死的有面子.md
@@ -1,0 +1,13 @@
+That's a curious paradox, isn't it? Claiming you "made the money" when an opportunity to earn was denied could imply a few things depending on the context:
+
+1. **Ego or Image Management**: Someone might say this to project an image of financial success or control, even if they turned down a real opportunity. It's a way of saving face or maintaining status.
+
+2. **Regret Masking**: The person might actually regret their decision but frame it as if they didn’t need the opportunity to feel better about their choice.
+
+3. **Misplaced Pride**: Sometimes, people deny opportunities for reasons they deem morally or personally significant, and they may frame the act of denial as a success itself—suggesting they "made" or "saved" their integrity, rather than money.
+
+4. **Confusion or Misdirection**: It could also be a deflection tactic, where they mix words to avoid addressing why the opportunity was actually denied or lost.
+
+5. **Metaphorical "Wealth"**: In some cases, people equate "making money" with gaining something else valuable—like time, freedom, or even peace of mind—that came from saying no.
+
+This statement can often reveal more about someone's psychology than their actual financial situation! What context are you thinking about?


### PR DESCRIPTION
That's a curious paradox, isn't it? Claiming you "made the money" when an opportunity to earn was denied could imply a few things depending on the context:

1. **Ego or Image Management**: Someone might say this to project an image of financial success or control, even if they turned down a real opportunity. It's a way of saving face or maintaining status.

2. **Regret Masking**: The person might actually regret their decision but frame it as if they didn’t need the opportunity to feel better about their choice.

3. **Misplaced Pride**: Sometimes, people deny opportunities for reasons they deem morally or personally significant, and they may frame the act of denial as a success itself—suggesting they "made" or "saved" their integrity, rather than money.

4. **Confusion or Misdirection**: It could also be a deflection tactic, where they mix words to avoid addressing why the opportunity was actually denied or lost.

5. **Metaphorical "Wealth"**: In some cases, people equate "making money" with gaining something else valuable—like time, freedom, or even peace of mind—that came from saying no.

This statement can often reveal more about someone's psychology than their actual financial situation! What context are you thinking about?